### PR TITLE
Fix: TypeScript build errors in dashboard fetchNotes calls

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -167,7 +167,7 @@ export default function DashboardPage() {
         console.error('Failed to delete note:', error);
         alert('Failed to delete note. Please try again.');
       } finally {
-        await fetchNotes({ showTrash: currentView === DASHBOARD_VIEWS.TRASH });
+        await fetchNotes(currentView === DASHBOARD_VIEWS.TRASH ? { showTrash: true } : undefined);
       }
     },
     [deleteNoteById, fetchNotes, handleCloseEditor, currentView]
@@ -186,7 +186,7 @@ export default function DashboardPage() {
   const handleShowAllNotes = useCallback(() => {
     setCurrentView(DASHBOARD_VIEWS.ALL_NOTES);
     clearTagSelection();
-    fetchNotes({ showTrash: false });
+    fetchNotes();
   }, [clearTagSelection, fetchNotes]);
 
   const handleShowTrash = useCallback(() => {


### PR DESCRIPTION
## Summary
Fixes TypeScript build failures that were blocking Vercel deployment after merging PR #25 (Favorites).

## Problem
The build was failing with type errors:
```
Type 'boolean' is not assignable to type 'true'
```

This occurred because the `FetchNotesOptions` type uses a discriminated union pattern that requires `showTrash` to be literally `true` (not any boolean value).

## Changes
- **Line 170**: Changed `fetchNotes({ showTrash: currentView === DASHBOARD_VIEWS.TRASH })` to use conditional logic that passes either `{ showTrash: true }` or `undefined`
- **Line 189**: Changed `fetchNotes({ showTrash: false })` to `fetchNotes()` without parameters

## Testing
- ✅ Build passes locally (`npm run build`)
- ✅ TypeScript compilation succeeds
- ✅ No new warnings introduced

## Type Definition
The `FetchNotesOptions` type enforces mutually exclusive options:
```typescript
type FetchNotesOptions =
  | { showTrash: true; showFavorites?: never }
  | { showTraash?: never; showFavorites: true }
  | { showTrash?: never; showFavorites?: never }
  | undefined;
```

This ensures you can't accidentally request both trash and favorites at the same time.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)