### PR TITLE
feat: Add email note functionality with Resend integration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -8,8 +8,9 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # Optional: For server-side operations
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 
-# Email-to-Note Feature (Resend)
-# The domain to use for inbound email addresses (e.g., notes.resend.dev or your custom domain)
+# Email Features (Resend)
+# Used for both sending notes via email and receiving emails to create notes
+# The domain to use for email addresses (e.g., send.expandnote.com or your custom domain)
 RESEND_EMAIL_DOMAIN=send.expandnote.com
 # Resend API key (get from https://resend.com/api-keys)
 RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "react-markdown": "^10.1.0",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
-        "resend": "^6.3.0-canary.4",
+        "resend": "^6.5.2",
         "zustand": "^5.0.8"
       },
       "devDependencies": {
@@ -9608,15 +9608,15 @@
       "license": "MIT"
     },
     "node_modules/resend": {
-      "version": "6.3.0-canary.4",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-6.3.0-canary.4.tgz",
-      "integrity": "sha512-jjP8k98qUEIU04uQXNf6+NoBETEYuVROlsVX0N7V/mYfz4Hetb2zDqiNHysYYLbMVTWKbX4H/CeclYNTQ/FIMA==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.5.2.tgz",
+      "integrity": "sha512-Yl83UvS8sYsjgmF8dVbNPzlfpmb3DkLUk3VwsAbkaEFo9UMswpNuPGryHBXGk+Ta4uYMv5HmjVk3j9jmNkcEDg==",
       "license": "MIT",
       "dependencies": {
         "svix": "1.76.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
         "@react-email/render": "*"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
-    "resend": "^6.3.0-canary.4",
+    "resend": "^6.5.2",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/src/app/api/email/webhook/route.ts
+++ b/src/app/api/email/webhook/route.ts
@@ -320,7 +320,7 @@ export async function POST(request: NextRequest) {
           }
 
           // Fetch the attachment details which includes the download_url
-          const { data: attachmentData, error: attachmentFetchError } = await resend.attachments.receiving.get({
+          const { data: attachmentData, error: attachmentFetchError } = await resend.emails.receiving.attachments.get({
             id: att.id,
             emailId: email_id,
           });

--- a/src/app/api/notes/[id]/email/route.ts
+++ b/src/app/api/notes/[id]/email/route.ts
@@ -2,6 +2,12 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Resend } from 'resend';
 import { createClient } from '@/lib/supabase/server';
 
+type RouteParams = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
 /**
  * POST /api/notes/[id]/email
  * Send a note via email using Resend
@@ -13,10 +19,10 @@ import { createClient } from '@/lib/supabase/server';
  */
 export async function POST(
   request: NextRequest,
-  context: { params: Promise<{ id: string }> }
+  { params }: RouteParams
 ) {
   try {
-    const { id: noteId } = await context.params;
+    const { id: noteId } = await params;
 
     // Parse request body
     const body = await request.json();

--- a/src/app/api/notes/[id]/email/route.ts
+++ b/src/app/api/notes/[id]/email/route.ts
@@ -1,0 +1,225 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Resend } from 'resend';
+import { createClient } from '@/lib/supabase/server';
+
+/**
+ * POST /api/notes/[id]/email
+ * Send a note via email using Resend
+ *
+ * Request body:
+ * - email: string (required) - destination email address
+ *
+ * Security: User must be authenticated and own the note
+ */
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: noteId } = await context.params;
+
+    // Parse request body
+    const body = await request.json();
+    const { email } = body;
+
+    // Validate email parameter
+    if (!email || typeof email !== 'string') {
+      return NextResponse.json(
+        { error: 'Email address is required' },
+        { status: 400 }
+      );
+    }
+
+    // Basic email validation
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return NextResponse.json(
+        { error: 'Invalid email address format' },
+        { status: 400 }
+      );
+    }
+
+    // Check for Resend API key
+    const resendApiKey = process.env.RESEND_API_KEY;
+    if (!resendApiKey) {
+      console.error('RESEND_API_KEY is not set');
+      return NextResponse.json(
+        { error: 'Email service not configured' },
+        { status: 500 }
+      );
+    }
+
+    // Initialize Resend client
+    const resend = new Resend(resendApiKey);
+
+    // Get authenticated user
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    // Fetch the note and verify ownership
+    const { data: note, error: noteError } = await supabase
+      .from('notes')
+      .select('id, title, content, user_id')
+      .eq('id', noteId)
+      .eq('user_id', user.id)
+      .is('deleted_at', null)
+      .maybeSingle();
+
+    if (noteError) {
+      console.error('Error fetching note:', noteError);
+      return NextResponse.json(
+        { error: 'Failed to fetch note' },
+        { status: 500 }
+      );
+    }
+
+    if (!note) {
+      return NextResponse.json(
+        { error: 'Note not found or you do not have permission to access it' },
+        { status: 404 }
+      );
+    }
+
+    // Get user info for "from" address
+    const { data: userData, error: userError } = await supabase
+      .from('users')
+      .select('email')
+      .eq('id', user.id)
+      .single();
+
+    if (userError || !userData) {
+      console.error('Error fetching user data:', userError);
+      return NextResponse.json(
+        { error: 'Failed to fetch user information' },
+        { status: 500 }
+      );
+    }
+
+    // Prepare email content
+    const noteTitle = note.title || 'Untitled Note';
+    const noteContent = note.content || '';
+
+    // Create HTML email content
+    const htmlContent = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      line-height: 1.6;
+      color: #333;
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 20px;
+    }
+    .header {
+      border-bottom: 2px solid #4F46E5;
+      padding-bottom: 10px;
+      margin-bottom: 20px;
+    }
+    .title {
+      font-size: 24px;
+      font-weight: bold;
+      color: #1F2937;
+      margin: 0 0 10px 0;
+    }
+    .content {
+      white-space: pre-wrap;
+      font-family: 'Monaco', 'Courier New', monospace;
+      font-size: 14px;
+      background-color: #F9FAFB;
+      padding: 15px;
+      border-radius: 5px;
+      border: 1px solid #E5E7EB;
+    }
+    .footer {
+      margin-top: 30px;
+      padding-top: 20px;
+      border-top: 1px solid #E5E7EB;
+      font-size: 12px;
+      color: #6B7280;
+      text-align: center;
+    }
+    .branding {
+      color: #4F46E5;
+      text-decoration: none;
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1 class="title">${noteTitle.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</h1>
+  </div>
+  <div class="content">${noteContent.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</div>
+  <div class="footer">
+    <p>Sent from <a href="https://expandnote.com" class="branding">ExpandNote</a></p>
+    <p>This note was shared by ${userData.email}</p>
+  </div>
+</body>
+</html>
+    `.trim();
+
+    // Create plain text version
+    const textContent = `
+${noteTitle}
+${'='.repeat(noteTitle.length)}
+
+${noteContent}
+
+---
+Sent from ExpandNote
+This note was shared by ${userData.email}
+    `.trim();
+
+    // Send email via Resend
+    try {
+      const { data: emailData, error: sendError } = await resend.emails.send({
+        from: `ExpandNote <noreply@${process.env.RESEND_EMAIL_DOMAIN || 'send.expandnote.com'}>`,
+        to: email,
+        subject: `Note: ${noteTitle}`,
+        html: htmlContent,
+        text: textContent,
+        reply_to: userData.email,
+      });
+
+      if (sendError) {
+        console.error('Resend API error:', sendError);
+        return NextResponse.json(
+          { error: 'Failed to send email', details: sendError.message },
+          { status: 500 }
+        );
+      }
+
+      return NextResponse.json({
+        success: true,
+        message: 'Email sent successfully',
+        email_id: emailData?.id,
+      });
+
+    } catch (sendError) {
+      console.error('Error sending email:', sendError);
+      return NextResponse.json(
+        { error: 'Failed to send email' },
+        { status: 500 }
+      );
+    }
+
+  } catch (error) {
+    console.error('Email sending error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/notes/[id]/email/route.ts
+++ b/src/app/api/notes/[id]/email/route.ts
@@ -196,7 +196,7 @@ This note was shared by ${userData.email}
         subject: `Note: ${noteTitle}`,
         html: htmlContent,
         text: textContent,
-        reply_to: userData.email,
+        replyTo: userData.email,
       });
 
       if (sendError) {

--- a/src/app/api/notes/[id]/email/route.ts
+++ b/src/app/api/notes/[id]/email/route.ts
@@ -143,17 +143,12 @@ export async function POST(
       );
     }
 
-    // Get user info for "from" address
-    const { data: userData, error: userError } = await supabase
-      .from('users')
-      .select('email')
-      .eq('id', user.id)
-      .single();
-
-    if (userError || !userData) {
-      console.error('Error fetching user data:', userError);
+    // Get user email from auth (already available from getUser())
+    const userEmail = user.email;
+    if (!userEmail) {
+      console.error('User email not available from auth');
       return NextResponse.json(
-        { error: 'Failed to fetch user information' },
+        { error: 'User email not found' },
         { status: 500 }
       );
     }
@@ -221,7 +216,7 @@ export async function POST(
   <div class="content">${noteContent.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</div>
   <div class="footer">
     <p>Sent from <a href="https://expandnote.com" class="branding">ExpandNote</a></p>
-    <p>This note was shared by ${userData.email}</p>
+    <p>This note was shared by ${userEmail}</p>
   </div>
 </body>
 </html>
@@ -236,7 +231,7 @@ ${noteContent}
 
 ---
 Sent from ExpandNote
-This note was shared by ${userData.email}
+This note was shared by ${userEmail}
     `.trim();
 
     // Send email via Resend
@@ -247,7 +242,7 @@ This note was shared by ${userData.email}
         subject: `Note: ${sanitizedTitle}`,
         html: htmlContent,
         text: textContent,
-        replyTo: userData.email,
+        replyTo: userEmail,
       });
 
       if (sendError) {

--- a/src/components/NoteEditor.tsx
+++ b/src/components/NoteEditor.tsx
@@ -42,6 +42,9 @@ export function NoteEditor({ note, onSave, onDelete, onClose, getTagsForNote, up
   const [executionProgress, setExecutionProgress] = useState<{ current: number; total: number } | null>(null);
   const [showVersionHistory, setShowVersionHistory] = useState(false);
   const [selectedVersionId, setSelectedVersionId] = useState<string | null>(null);
+  const [showEmailModal, setShowEmailModal] = useState(false);
+  const [emailAddress, setEmailAddress] = useState('');
+  const [isSendingEmail, setIsSendingEmail] = useState(false);
 
   // Ref for textarea to manage cursor position
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -54,6 +57,24 @@ export function NoteEditor({ note, onSave, onDelete, onClose, getTagsForNote, up
 
   // Cache last version content to avoid repeated DB queries
   const lastVersionContentRef = useRef<Map<string, string | null>>(new Map());
+
+  // Fetch user email when email modal opens
+  useEffect(() => {
+    const fetchUserEmail = async () => {
+      if (showEmailModal && !emailAddress) {
+        try {
+          const supabase = createClient();
+          const { data: { user } } = await supabase.auth.getUser();
+          if (user?.email) {
+            setEmailAddress(user.email);
+          }
+        } catch (error) {
+          console.error('Failed to fetch user email:', error);
+        }
+      }
+    };
+    fetchUserEmail();
+  }, [showEmailModal, emailAddress]);
 
   // Reset state when note ID changes (not just when note object reference changes)
   useEffect(() => {
@@ -668,6 +689,47 @@ export function NoteEditor({ note, onSave, onDelete, onClose, getTagsForNote, up
     }
   }, [content]);
 
+  // Send note via email
+  const handleSendEmail = useCallback(async () => {
+    if (!note || !emailAddress.trim()) {
+      toast.error('Please enter an email address');
+      return;
+    }
+
+    // Basic email validation
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(emailAddress)) {
+      toast.error('Please enter a valid email address');
+      return;
+    }
+
+    setIsSendingEmail(true);
+
+    try {
+      const response = await fetch(`/api/notes/${note.id}/email`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email: emailAddress }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Failed to send email');
+      }
+
+      toast.success(`Note sent to ${emailAddress}`);
+      setShowEmailModal(false);
+      setEmailAddress('');
+    } catch (error) {
+      console.error('Failed to send email:', error);
+      toast.error(error instanceof Error ? error.message : 'Failed to send email');
+    } finally {
+      setIsSendingEmail(false);
+    }
+  }, [note, emailAddress]);
+
   // View a specific version
   const handleViewVersion = useCallback((versionId: string) => {
     setSelectedVersionId(versionId);
@@ -847,6 +909,18 @@ export function NoteEditor({ note, onSave, onDelete, onClose, getTagsForNote, up
             </button>
           )}
 
+          {/* Email Button */}
+          {note && (
+            <button
+              onClick={() => setShowEmailModal(true)}
+              className="p-2 text-[var(--foreground-secondary)] hover:text-[var(--foreground)] hover:bg-[var(--background)] rounded-lg transition-colors"
+              aria-label="Email note"
+              title="Email note"
+            >
+              <span className="material-symbols-outlined text-lg">mail</span>
+            </button>
+          )}
+
           {note && onDelete && (
             <button
               onClick={handleDelete}
@@ -995,6 +1069,81 @@ export function NoteEditor({ note, onSave, onDelete, onClose, getTagsForNote, up
           onClose={() => setSelectedVersionId(null)}
           onRestore={() => handleRestoreVersion(selectedVersionId)}
         />
+      )}
+
+      {/* Email Modal */}
+      {showEmailModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-[var(--background-surface)] rounded-lg shadow-xl max-w-md w-full p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold text-[var(--foreground)]">Email Note</h3>
+              <button
+                onClick={() => {
+                  setShowEmailModal(false);
+                  setEmailAddress('');
+                }}
+                className="p-1 text-[var(--foreground-secondary)] hover:text-[var(--foreground)] rounded transition-colors"
+                aria-label="Close modal"
+              >
+                <span className="material-symbols-outlined text-xl">close</span>
+              </button>
+            </div>
+
+            <div className="mb-4">
+              <label htmlFor="email-input" className="block text-sm font-medium text-[var(--foreground)] mb-2">
+                Email Address
+              </label>
+              <input
+                id="email-input"
+                type="email"
+                value={emailAddress}
+                onChange={(e) => setEmailAddress(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !isSendingEmail) {
+                    handleSendEmail();
+                  }
+                }}
+                placeholder="Enter email address"
+                className="w-full px-3 py-2 border border-[var(--border)] rounded-lg focus:outline-none focus:ring-2 focus:ring-[var(--primary)] bg-[var(--background)] text-[var(--foreground)]"
+                disabled={isSendingEmail}
+                autoFocus
+              />
+              <p className="mt-2 text-xs text-[var(--foreground-secondary)]">
+                The note will be sent to this email address.
+              </p>
+            </div>
+
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => {
+                  setShowEmailModal(false);
+                  setEmailAddress('');
+                }}
+                className="px-4 py-2 text-sm font-medium text-[var(--foreground-secondary)] hover:text-[var(--foreground)] hover:bg-[var(--background)] rounded-lg transition-colors"
+                disabled={isSendingEmail}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSendEmail}
+                disabled={isSendingEmail || !emailAddress.trim()}
+                className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-[var(--primary)] hover:opacity-90 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isSendingEmail ? (
+                  <>
+                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+                    <span>Sending...</span>
+                  </>
+                ) : (
+                  <>
+                    <span className="material-symbols-outlined text-base">send</span>
+                    <span>Send</span>
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/components/NoteEditor.tsx
+++ b/src/components/NoteEditor.tsx
@@ -60,20 +60,28 @@ export function NoteEditor({ note, onSave, onDelete, onClose, getTagsForNote, up
 
   // Fetch user email when email modal opens
   useEffect(() => {
+    let isCancelled = false;
+
     const fetchUserEmail = async () => {
       if (showEmailModal && !emailAddress) {
         try {
           const supabase = createClient();
           const { data: { user } } = await supabase.auth.getUser();
-          if (user?.email) {
+          if (user?.email && !isCancelled) {
             setEmailAddress(user.email);
           }
         } catch (error) {
-          console.error('Failed to fetch user email:', error);
+          if (!isCancelled) {
+            console.error('Failed to fetch user email:', error);
+          }
         }
       }
     };
     fetchUserEmail();
+
+    return () => {
+      isCancelled = true;
+    };
   }, [showEmailModal, emailAddress]);
 
   // Reset state when note ID changes (not just when note object reference changes)

--- a/supabase/migrations/20251204171350_create_email_sends_rate_limiting.sql
+++ b/supabase/migrations/20251204171350_create_email_sends_rate_limiting.sql
@@ -1,0 +1,27 @@
+-- Table to track email sends for rate limiting
+CREATE TABLE email_sends (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  note_id UUID REFERENCES notes(id) ON DELETE SET NULL,
+  recipient_email TEXT NOT NULL,
+  sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for fast rate limit lookups
+CREATE INDEX idx_email_sends_user_time ON email_sends(user_id, sent_at DESC);
+
+-- Enable RLS
+ALTER TABLE email_sends ENABLE ROW LEVEL SECURITY;
+
+-- Users can only see their own email sends
+CREATE POLICY "Users can view their own email sends"
+  ON email_sends FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Users can insert their own email sends
+CREATE POLICY "Users can insert their own email sends"
+  ON email_sends FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- Add comment
+COMMENT ON TABLE email_sends IS 'Tracks email sends for rate limiting (10 per user per hour)';

--- a/supabase/migrations/20251204180000_add_email_sends_status.sql
+++ b/supabase/migrations/20251204180000_add_email_sends_status.sql
@@ -1,0 +1,13 @@
+-- Add status column to email_sends for race condition prevention
+-- Status tracks: pending (reserved slot), sent (successful), failed (error)
+ALTER TABLE email_sends ADD COLUMN status TEXT NOT NULL DEFAULT 'sent';
+
+-- Add check constraint for valid status values
+ALTER TABLE email_sends ADD CONSTRAINT email_sends_status_check
+  CHECK (status IN ('pending', 'sent', 'failed'));
+
+-- Add index for cleanup queries (finding old pending/failed entries)
+CREATE INDEX idx_email_sends_status ON email_sends(status) WHERE status != 'sent';
+
+-- Comment
+COMMENT ON COLUMN email_sends.status IS 'Email send status: pending (reserved), sent (success), failed (error)';


### PR DESCRIPTION
Closes #42

## Summary
Implements the ability to email notes to users using Resend. Notes can be sent to the user's sign-up email by default, with the ability to override the recipient address.

## Changes
- Created API endpoint at `/api/notes/[id]/email/route.ts` to send notes via email
- Added email button to NoteEditor toolbar
- Added email modal with pre-populated user email
- Format emails with HTML and plain text versions
- Updated environment variable documentation

## Testing
- Requires `RESEND_API_KEY` and `RESEND_EMAIL_DOMAIN` in environment
- Email button appears in note editor toolbar
- Modal pre-fills with user's email, can be overridden
- Emails sent via Resend with formatted HTML content

🤖 Generated with [Claude Code](https://claude.ai/code)